### PR TITLE
When cloning, the COWEpoch is not created in the right enclosing object

### DIFF
--- a/src/main/java/edu/stanford/ppl/concurrent/CopyOnWriteManager.java
+++ b/src/main/java/edu/stanford/ppl/concurrent/CopyOnWriteManager.java
@@ -212,8 +212,13 @@ abstract public class CopyOnWriteManager<E> implements Cloneable {
             a = succ;
         }
 
-        copy._active = new COWEpoch(cloneFrozen(f), f, a.initialSize);
+        copy.createNewEpoch(f, a);
         return copy;
+    }
+
+    private void createNewEpoch(E f, COWEpoch a)
+    {
+        _active = new COWEpoch(cloneFrozen(f), f, a.initialSize);
     }
 
     /** Returns a reference to the tree structure suitable for a read

--- a/src/test/java/edu/stanford/ppl/concurrent/SnapTreeTest.java
+++ b/src/test/java/edu/stanford/ppl/concurrent/SnapTreeTest.java
@@ -1,0 +1,26 @@
+/* SnapTree - (c) 2009 Stanford University - PPL */
+
+// SnapTreeTest
+package edu.stanford.ppl.concurrent;
+
+import java.util.Iterator;
+import junit.framework.TestCase;
+
+public class SnapTreeTest extends TestCase {
+
+    public void testInnerObjectBug() {
+        SnapTreeMap<Integer, Integer> map = new SnapTreeMap<Integer, Integer>();
+        SnapTreeMap<Integer, Integer> map2;
+        map2 = map.clone();
+        map2.put(1, 1);
+
+        Iterator<Integer> iter = map2.values().iterator();
+        while (iter.hasNext())
+        {
+            iter.next();
+            iter.remove();
+        }
+
+        assert map2.size() == 0;
+    }
+}


### PR DESCRIPTION
COWEpoch are inner object. When a CopyOnWriteManager is cloned, the new COWEpoch for the clone is created by the initial object rather than the clone. I believe this is wrong, and leads to problem when later the COWEpoch affects _active (in onClosed), affecting the original object rather than the clone.

The commit includes a small unit test demonstrating the bug (I got lazy and created a SnapTree test bug it's likely possible to simply have CopyOnWriteManagerTest), as well as a simple fix.
